### PR TITLE
Fix odd number sequence generation

### DIFF
--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -117,8 +117,11 @@ const generateLevel3Question = (): Question => {
     (start: number, step?: number) => [start, start - step!, start - step! * 2, start - step! * 3],
     // Even numbers
     (start: number) => [start, start + 2, start + 4, start + 6],
-    // Odd numbers
-    (start: number) => [start, start + 2, start + 4, start + 6]
+    // Odd numbers - ensure starting value is odd
+    (start: number) => {
+      const oddStart = start % 2 === 0 ? start + 1 : start;
+      return [oddStart, oddStart + 2, oddStart + 4, oddStart + 6];
+    }
   ];
 
   // Randomly select a pattern


### PR DESCRIPTION
## Summary
- ensure odd sequence pattern uses an odd start value
- update comment for the corrected logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f4fb3dc832c93f82d76b385d3fe