### PR TITLE
Add vitest and unit tests for question generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ För att bygga produktionversionen:
 npm run build
 ```
 
+## Tester
+
+Kör alla enhetstester med:
+```bash
+npm run test
+```
+
 ## Hosting
 
 Efter byggning finns de färdiga filerna i `dist`-mappen som kan hostas på vilken webbserver som helst.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -25,6 +26,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/utils/__tests__/mathUtils.test.ts
+++ b/src/utils/__tests__/mathUtils.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateLevel1Question,
+  generateLevel2Question,
+  generateLevel3Question,
+} from '../mathUtils'
+
+describe('generateLevel1Question', () => {
+  it('creates valid addition and subtraction questions', () => {
+    for (let i = 0; i < 50; i++) {
+      const q = generateLevel1Question()
+      expect(q.options).toHaveLength(4)
+      expect(new Set(q.options).size).toBe(4)
+      expect(q.options).toContain(q.correctAnswer)
+
+      const match = q.expression.match(/(\d+)\s*([+-])\s*(\d+)/)
+      expect(match).not.toBeNull()
+      const first = parseInt(match![1], 10)
+      const op = match![2]
+      const second = parseInt(match![3], 10)
+
+      expect(first).toBeGreaterThanOrEqual(1)
+      expect(first).toBeLessThanOrEqual(20)
+      expect(second).toBeGreaterThanOrEqual(1)
+      expect(second).toBeLessThanOrEqual(20)
+      const result = op === '+' ? first + second : first - second
+      expect(result).toBe(q.correctAnswer)
+      expect(result).toBeGreaterThanOrEqual(0)
+      expect(result).toBeLessThanOrEqual(20)
+    }
+  })
+})
+
+describe('generateLevel2Question', () => {
+  it('creates valid three number expressions', () => {
+    for (let i = 0; i < 50; i++) {
+      const q = generateLevel2Question()
+      expect(q.options).toHaveLength(4)
+      expect(new Set(q.options).size).toBe(4)
+      expect(q.options).toContain(q.correctAnswer)
+
+      const match = q.expression.match(/(\d+)\s*([+-])\s*(\d+)\s*([+-])\s*(\d+)/)
+      expect(match).not.toBeNull()
+      const a = parseInt(match![1], 10)
+      const op1 = match![2]
+      const b = parseInt(match![3], 10)
+      const op2 = match![4]
+      const c = parseInt(match![5], 10)
+
+      ;[a, b, c].forEach(n => {
+        expect(n).toBeGreaterThanOrEqual(0)
+        expect(n).toBeLessThanOrEqual(15)
+      })
+
+      const intermediate = op1 === '+' ? a + b : a - b
+      const result = op2 === '+' ? intermediate + c : intermediate - c
+      expect(result).toBe(q.correctAnswer)
+      expect(result).toBeGreaterThanOrEqual(0)
+      expect(result).toBeLessThanOrEqual(25)
+    }
+  })
+})
+
+describe('generateLevel3Question', () => {
+  it('creates valid number sequences', () => {
+    for (let i = 0; i < 50; i++) {
+      const q = generateLevel3Question()
+      expect(q.options).toHaveLength(4)
+      expect(new Set(q.options).size).toBe(4)
+      expect(q.options).toContain(q.correctAnswer)
+
+      const match = q.expression.match(/\[(\d+)\] \[(\d+)\] \[(\d+)\] \[\?\]/)
+      expect(match).not.toBeNull()
+      const nums = match!.slice(1, 4).map(v => parseInt(v, 10))
+      nums.forEach(n => {
+        expect(n).toBeGreaterThanOrEqual(0)
+        expect(n).toBeLessThanOrEqual(30)
+      })
+
+      const step1 = nums[1] - nums[0]
+      const step2 = nums[2] - nums[1]
+      expect(step1).toBe(step2)
+      const result = nums[2] + step1
+      expect(result).toBe(q.correctAnswer)
+      expect(result).toBeGreaterThanOrEqual(0)
+      expect(result).toBeLessThanOrEqual(30)
+    }
+  })
+})

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -171,4 +171,10 @@ export const generateQuestion = (level: number): Question => {
 
 export const generateQuestions = (count: number, level: number): Question[] => {
   return Array.from({ length: count }, () => generateQuestion(level));
-}; 
+};
+
+export {
+  generateLevel1Question,
+  generateLevel2Question,
+  generateLevel3Question,
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- add `vitest` and configure tests
- expose level-specific question helpers
- create tests for math utility functions
- document `npm run test` in README

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f64cd88832c876c996a82fcb70a